### PR TITLE
Improve forward propagation

### DIFF
--- a/src/neural_network/NeuralNetwork.py
+++ b/src/neural_network/NeuralNetwork.py
@@ -114,26 +114,13 @@ class NeuralNetwork:
     def forward_propagation(self):
         self.reset_neurons()
 
-        open_list = self.output_neurons.copy()
-        closed_list = []
-        active_neuron_can_be_closed = False
+        working_neurons = self.input_neurons.copy()
 
-        while len(open_list) > 0:
-            for active_neuron in open_list:
-                active_neuron_can_be_closed = True
-                for neuron_backwards in self.get_connected_neurons_backward(active_neuron):
-                    if neuron_backwards not in closed_list:
-                        active_neuron_can_be_closed = False
-                        if neuron_backwards not in open_list:
-                            open_list.append(neuron_backwards)
-                if active_neuron_can_be_closed:
-                    open_list.remove(active_neuron)
-                    closed_list.append(active_neuron)
-                    for neuron_backwards in self.get_connected_neurons_backward(active_neuron):
-                        active_neuron.value += neuron_backwards.value * self.get_connection_weight(neuron_backwards,
-                                                                                                   active_neuron)
-
-        return self
+        for neuron in working_neurons:
+            for neuron_forward in self.get_connected_neurons_forward(neuron):
+                neuron_forward.value += neuron.value * self.get_connection_weight(neuron, neuron_forward)
+                if neuron_forward not in working_neurons:
+                    working_neurons.append(neuron_forward)
 
     def get_output_values(self):
         output_values = []
@@ -147,9 +134,9 @@ class NeuralNetwork:
             expected_output_values.append(neuron.expected_value)
         return expected_output_values
 
-    def get_connection_weight(self, neuron_backwards, active_neuron):
+    def get_connection_weight(self, neuron_from, neuron_to):
         for connection in self.connections:
-            if connection.neuron_from == neuron_backwards and connection.neuron_to == active_neuron:
+            if connection.neuron_from == neuron_from and connection.neuron_to == neuron_to:
                 return connection.weight
 
     def set_expected_output_values(self, param):

--- a/src/neural_network/tests/test_neural_network.py
+++ b/src/neural_network/tests/test_neural_network.py
@@ -126,14 +126,19 @@ def test_forward_propagation():
     neuron_from1 = Neuron(value=2)
     neuron_from2 = Neuron(value=3)
     neuron_to = Neuron()
+
     nn.add_input_neuron(neuron_from1)
     nn.add_input_neuron(neuron_from2)
     nn.add_output_neuron(neuron_to)
+
     nn.add_connection(neuron_from1, neuron_to, 1)
     nn.add_connection(neuron_from2, neuron_to, 2)
+    nn.add_connection(neuron_to, neuron_from1, 3)
+
     nn.forward_propagation()
 
     assert neuron_to.value == 8
+    assert neuron_from1.value == 26
 
 
 def test_forward_propagation_2():
@@ -339,11 +344,7 @@ def test_random_weight_mutation():
     nn.add_connection(neuron_input1, neuron_output1, 1)
     nn.add_connection(neuron_input1, neuron_output2, 1)
 
-    print("Vor dem mutieren:", nn.forward_propagation().get_output_values())
-
     nn.random_mutate_weight(0.5)
-
-    print("Nach dem mutieren", nn.forward_propagation().get_output_values())
 
     first_connection_changed = nn.get_connection_between_neurons(neuron_input1, neuron_output1).weight != 1
     second_connection_changed = nn.get_connection_between_neurons(neuron_input1, neuron_output2).weight != 1


### PR DESCRIPTION
Instead of going from back to front, we go from front to back. Likewise, neurons can now be connected in loops.

Will probably have to be edited again later when the tick system is introduced. Currently, however, it is simulated as if all neurons have a firing rate of 1 or are limited to exactly 1 tick cycle.